### PR TITLE
FindSim package on PyPi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,4 @@ script:
     - cp ./.travis/matplotlibrc .
     - python -m pip install .
     - python -m pip install pymoose --pre --upgrade # till we relase 3.2.0
-    - ./test.sh
+    - ./test.sh 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,5 @@ before_script:
 script:
     - cp ./.travis/matplotlibrc .
     - python -m pip install .
+    - python -m pip install pymoose --pre --upgrade # till we relase 3.2.0
     - ./test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,5 @@ before_script:
 
 script:
     - cp ./.travis/matplotlibrc .
-    - python -m pip install
+    - python -m pip install .
     - ./test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,5 @@ before_script:
 
 script:
     - cp ./.travis/matplotlibrc .
+    - python -m pip install
     - ./test.sh

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include . *.xml

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Quick start:
 A. Run one of the example experiments on the default model, generating a graph 
 to compare model to experiment:
 
-1. Install MOOSE
+1. Install MOOSE (Instructions can be found here: http://moose.readthedocs.io/en/latest/install/install.html )
 2. Install FindSim:
 	git clone https://github.com/BhallaLab/FindSim
 3. Navigate to release or to development branch, e.g.,

--- a/README.md
+++ b/README.md
@@ -34,16 +34,16 @@ To run FindSim script one needs to
 
 # File organization:
 
-FindSim/             				: project directory  
-FindSim/stable					: Stable branch. Stable version of `develop` branch  
-FindSim/Curated					: Folder contains FindSim worksheets to which the model is well fit.
-FindSim/models					: Model files 
-FindSim/findSim.py				: Main findSim script  
-FindSim/runAllParallel.py			: Batch/parallel wrapper script.  
-FindSim/FindSim-Exptworksheet.xlsx		: Template worksheet with inline help and units, for Microsoft Excel.  
-FindSim/FindSim-Exptworksheet.ods		: Template worksheet with inline help and units, for Libre Office.  
-FindSim/FindSim-Schema.xml 			: Schema for tsv files for worksheet.  
-FindSim/README.md				: This file  
+    FindSim/             				: project directory  
+    FindSim/stable					: Stable branch. Stable version of `develop` branch  
+    FindSim/Curated					: Folder contains FindSim worksheets to which the model is well fit.
+    FindSim/models					: Model files 
+    FindSim/findSim.py				: Main findSim script  
+    FindSim/runAllParallel.py			: Batch/parallel wrapper script.  
+    FindSim/FindSim-Exptworksheet.xlsx		: Template worksheet with inline help and units, for Microsoft Excel.  
+    FindSim/FindSim-Exptworksheet.ods		: Template worksheet with inline help and units, for Libre Office.  
+    FindSim/FindSim-Schema.xml 			: Schema for tsv files for worksheet.  
+    FindSim/README.md				: This file  
 						
 # Quick start: 
 

--- a/README.md
+++ b/README.md
@@ -14,114 +14,185 @@ provides a score that reports how closely the two match.
 # LICENSE
 This file and the files in this repository are licensed under GPL v3 or later.
 
-# Version
-
-Latest release is 1.1.0, which can be downloadable at https://github.com/BhallaLab/FindSim/archive/v1.1.0.zip 
-
 # Install 
 
-To run FindSim script one needs to  
+One can get `FindSim` using `python-pip`.
+
+To install last stable release (__NOTE__ This uses moose version 3.1.4 (outdated
+with this release))
+
+     $ pip install FindSim 
+
+Or, to install the nightly built,
+
+     $ pip install FinSim --pre   # recommended 
+
+Alternatively, you can download the source code and install it yourself.
 
 1. Install MOOSE which can be found here https://moose.ncbs.res.in/readthedocs/install/install.html  
-2. Install FindSim:  
-  - Clone this repository using  
-     `git clone https://github.com/BhallaLab/FindSim`
+2. Install FindSim
 
-  - or, clone specific branch such as "devel" using:
-     `git clone -b devel https://github.com/BhallaLab/FindSim`
+```
+git clone https://github.com/BhallaLab/FindSim
+cd FindSim
+python setup.py install  
+```
 
-# File organization:
+After successful installation, two commands are available at your disposal
+`findsim` and `findsim_parallel`. To see the help message, pass `-h` option to
+either of these commands. For example, `findsim -h` will show you following
+message.
 
-    FindSim/             				: project directory  
-    FindSim/stable					: Stable branch. Stable version of `develop` branch  
-    FindSim/Curated					: Folder contains FindSim worksheets to which the model is well fit.
-    FindSim/models					: Model files 
-    FindSim/findSim.py				: Main findSim script  
-    FindSim/runAllParallel.py			: Batch/parallel wrapper script.  
-    FindSim/FindSim-Exptworksheet.xlsx		: Template worksheet with inline help and units, for Microsoft Excel.  
-    FindSim/FindSim-Exptworksheet.ods		: Template worksheet with inline help and units, for Libre Office.  
-    FindSim/FindSim-Schema.xml 			: Schema for tsv files for worksheet.  
-    FindSim/README.md				: This file  
+```
+usage: findsim [-h] [-m MODEL] [-d DUMP_SUBSET] [-p PARAM_FILE] [-t] [-hp]
+               [-hs] [-o] [-s SCALE_PARAM SCALE_PARAM SCALE_PARAM]
+               [-settle_time SETTLE_TIME]
+               script
+
+FindSim argument parser This program loads a kinetic model, and runs it with
+the specified stimuli. The output is then compared with expected output
+specified in the same file, to generate a model score.
+
+positional arguments:
+  script                Required: filename of experiment spec, in tsv format.
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -m MODEL, --model MODEL
+                        Optional: model filename, .g or .xml
+  -d DUMP_SUBSET, --dump_subset DUMP_SUBSET
+                        Optional: dump selected subset of model into named
+                        file
+  -p PARAM_FILE, --param_file PARAM_FILE
+                        Optional: Generate file of tweakable params belonging
+                        to selected subset of model
+  -t, --tabulate_output
+                        Flag: Print table of plot values. Default is NOT to
+                        print table
+  -hp, --hide_plot      Hide plot output of simulation along with expected
+                        values. Default is to show plot.
+  -hs, --hide_subplots  Hide subplot output of simulation. By default the
+                        graphs include dotted lines to indicate individual
+                        quantities (e.g., states of a molecule) that are being
+                        summed to give a total response. This flag turns off
+                        just those dotted lines, while leaving the main plot
+                        intact.
+  -o, --optimize_elec   Optimize electrical computation. By default the
+                        electrical computation runs for the entire duration of
+                        the simulation. With this flag the system turns off
+                        the electrical engine except during the times when
+                        electrical stimuli are being given. This can be *much*
+                        faster.
+  -s SCALE_PARAM SCALE_PARAM SCALE_PARAM, --scale_param SCALE_PARAM SCALE_PARAM SCALE_PARAM
+                        Scale specified object.field by ratio.
+  -settle_time SETTLE_TIME, --settle_time SETTLE_TIME
+                        Run model for specified settle time and return dict of
+                        {path,conc}.
 						
-# Quick start: 
-
-A. Run one of the example experiments on the default model, generating a graph to compare model to experiment:  
-To run the script, run the command in python and `synSynth7.g` is the latest model that is tested out the worksheets.  
-
-```
-python findSim.py Curated/FindSim-Jain2009-Fig2B.tsv --model models/synSynth7.g  
-```
-or,
-
-```
-python findSim.py Curated/FindSim-Jain2009-Fig2B.tsv  
 ```
 
-B. Batch run:  
+Command `findsim_parellel` is a helper utility: it runs multiple simulations
+using `findsim` in parellel.
 
-- runAllParallel.py script runs the findSim program on all tsv files in the specified directory, computes their scores, and prints out basic stats of the scores. It can do this in parallel using Python's multiprocessing library.  
+# Quick start
+
+To run one of the example experiments on the default model (`synSynth7.g`) and generate a graph 
+to compare model to experiment.  
+
+```
+findsim Curated/FindSim-Jain2009-Fig2B.tsv  
+```
+
+You can also pass the model explicitly, 
+
+```
+findsim Curated/FindSim-Jain2009-Fig2B.tsv --model models/synSynth7.g  
+```
+
+
+## Batch run
+
+To findSim program on all tsv files in the specified directory, computes their
+scores, and prints out basic stats of the scores, you should use
+`findsim_parallel` command.
 	
 ```
-python runAllParallel.py Curated -n 8  (run of the entire set of `Curated` experiments on 8 cores)  
-```
-or,
-
-```
-python runAllParallel.py Directory (of tsv files) -n (Number of processes to spawn) --model (synSynth7.g)  
+findsim_parellel Curated -n 8 
 ```
 
-C. Help:  
+It will run the entire set of `Curated` experiments in parallel using 8
+independant processes (it will be effectively if your computer has at least 8
+cores). The value of `-n` should not be more than `N+1` where `N` is the number
+of processors on your system (use system utility `nproc` to see this number).
+
+More detailed invocation of this command looks like the following:
 
 ```
-python findSim.py -h  
-python runAllParallel.py -h  
+findsim_parallel path/to/tsv/files -n 6 --model synSynth7.g
 ```
+
+# Repository organization
+
+    FindSim/             		: project directory  
+    FindSim/stable			: Stable branch. Stable version of `develop` branch  
+    FindSim/Curated	   		: Folder contains FindSim worksheets to which the model is well fit.
+    FindSim/models			: Model files 
+    FindSim/findSim.py			: Main findSim script  
+    FindSim/runAllParallel.py		: Batch/parallel wrapper script.  
+    FindSim/FindSim-Exptworksheet.xlsx	: Template worksheet with inline help and units, for Microsoft Excel.  
+    FindSim/FindSim-Exptworksheet.ods	: Template worksheet with inline help and units, for Libre Office.  
+    FindSim/FindSim-Schema.xml 		: Schema for tsv files for worksheet.  
+    FindSim/README.md			: This file  
 
 # Extra
 
-Generating Figures for   
-"FindSim: a Framework for Integrating Neuronal Data and Signaling Models."  
-by  Nisha A. Viswan, G.V. HarshaRani, Melanie I. Stefan, Upinder S. Bhalla
-Front Neuroinform. 2018 Jun 26;12:38. doi: 10.3389/fninf.2018.00038. eCollection 2018.
+Generating Figures for  __FindSim: a Framework for Integrating Neuronal Data
+and Signaling Models by  Nisha A. Viswan, G.V. HarshaRani, Melanie I. Stefan,
+Upinder S. Bhalla Front Neuroinform. 2018 Jun 26;12:38. doi:
+10.3389/fninf.2018.00038. eCollection 2018.__
 
-All these are run using the development branch "stable"  
-Please change into the branch to run these.  
+All these are run using the branch `release.1.1.0`. Please change into the
+branch to run these.
 
 Figure 6: bottom  
-python findSim.py Curated/FindSim-Jain2009_Fig4F.tsv --model models/synSynth7.g  
+    python findSim.py Curated/FindSim-Jain2009_Fig4F.tsv --model models/synSynth7.g  
 
 Figure 7B:  
-python findSim.py Curated/FindSim-Bhalla1999_fig2B.tsv --model models/synSynth7.g  
-python findSim.py Curated/FindSim-Gu2004_Fig3.tsv --model models/synSynth7.g  
+    python findSim.py Curated/FindSim-Bhalla1999_fig2B.tsv --model models/synSynth7.g  
+    python findSim.py Curated/FindSim-Gu2004_Fig3.tsv --model models/synSynth7.g  
 
 Figure 7C:  
-python findSim.py Curated/FindSim-Ji2010_fig1C_ERK_acute.tsv --model models/synSynth7.g  
+    python findSim.py Curated/FindSim-Ji2010_fig1C_ERK_acute.tsv --model models/synSynth7.g  
 
 Figure 7D:  
-python findSim.py Curated/FindSim-Bhalla1999_fig4C.tsv --model models/synSynth7.g  
+    python findSim.py Curated/FindSim-Bhalla1999_fig4C.tsv --model models/synSynth7.g  
+
 
 # Other resources
 
-Project is hosted at https://github.com/BhallaLab/FindSim
+- The web template for experiment worksheet can be found here
+https://www.ncbs.res.in/faculty/bhalla-findsim/worksheet  
 
-The web template for experiment worksheet can be found here https://www.ncbs.res.in/faculty/bhalla-findsim/worksheet  
+- The MOOSE site: http://moose.ncbs.res.in. MOOSE documentation:
+  http://moose.ncbs.res.in/readthedocs/install/index_install.html
 
-The MOOSE site: http://moose.ncbs.res.in  
+- Two papers were used as the initial basis for the models, and which in turn
+  refer to a large number of experimental studies for their data:
 
-MOOSE documentation: http://moose.ncbs.res.in/readthedocs/install/index_install.html  
+    1. Bhalla US., Iyengar R. Emergent properties of networks of biological signaling pathways. Science. 1999 Jan 15;283(5400):381-7.  
+    2. Jain P, and Bhalla, U.S. Signaling logic of activity-triggered dendritic protein synthesis: an mTOR gate but not a feedback switch. PLoS Comput Biol. 2009 Feb;5(2):e1000287. Epub 2009 Feb 13  
 
-Two papers were used as the initial basis for the models, and which in turn
-refer to a large number of experimental studies for their data:  
+- Two more papers were used for some of the experiments
 
-- Bhalla US., Iyengar R. Emergent properties of networks of biological signaling pathways. Science. 1999 Jan 15;283(5400):381-7.  
-- Jain P, and Bhalla, U.S. Signaling logic of activity-triggered dendritic protein synthesis: an mTOR gate but not a feedback switch. PLoS Comput Biol. 2009 Feb;5(2):e1000287. Epub 2009 Feb 13  
+    1. Gu J, et al. Beta1,4-N-Acetylglucosaminyltransferase III down-regulates
+       neurite outgrowth induced by costimulation of epidermal growth factor and
+       integrins through the Ras/ERK signaling pathway in PC12 cells.
+       Glycobiology. 2004 Feb;14(2):177-86. Epub 2003 Oct 23
+    2. Ji Y, et al. Acute and gradual increases in BDNF concentration elicit
+       distinct signaling and functions in neurons. Nat Neurosci. 2010
+       Mar;13(3):302-9. doi: 10.1038/nn.2505. Epub 2010 Feb 21.
 
-Two further papers were used for some of the experiments:  
-
-- Gu J, et al. Beta1,4-N-Acetylglucosaminyltransferase III down-regulates neurite outgrowth induced by costimulation of epidermal growth factor and integrins through the Ras/ERK signaling pathway in PC12 cells. Glycobiology. 2004 Feb;14(2):177-86. Epub 2003 Oct 23  
-- Ji Y, et al. Acute and gradual increases in BDNF concentration elicit distinct signaling and functions in neurons. Nat Neurosci. 2010 Mar;13(3):302-9. doi: 10.1038/nn.2505. Epub 2010 Feb 21.  
-
-DOQCS database, from which models were derived: http://doqcs.ncbs.res.in
-__Sivakumaran S. et al. The Database of Quantitative Cellular Signaling:
-management and analysis of chemical kinetic models of signaling networks.
-Bioinformatics. 2003. 19(3):408–415__
+- DOQCS database, from which models were derived: http://doqcs.ncbs.res.in
+  __Sivakumaran S. et al. The Database of Quantitative Cellular Signaling:
+  management and analysis of chemical kinetic models of signaling networks.
+  Bioinformatics. 2003. 19(3):408–415__

--- a/README.md
+++ b/README.md
@@ -16,60 +16,74 @@ This file and the files in this repository are licensed under GPL v3 or later.
 
 # Version
 
-Latest release is 1.1.0, which can be downloadable at  
-	https://github.com/BhallaLab/FindSim/archive/v1.1.0.zip  
-	https://github.com/BhallaLab/FindSim/archive/v1.1.0.tar.gz
+Latest release is 1.1.0, which can be downloadable at
+https://github.com/BhallaLab/FindSim/archive/v1.1.0.zip 
 
 
 # Install 
-	To run FindSim script one needs to  
-		- Install MOOSE which can be found here  
-			https://moose.ncbs.res.in/readthedocs/install/install.html  
-		- Install FindSim:  
-			Clone the entire repository using  
-  				>git clone https://github.com/BhallaLab/FindSim 
-			or, clone specific branch such as "stable" using:
-				>git clone -b <branch-name> https://github.com/BhallaLab/FindSim
 
-=============================================================================
+To run FindSim script one needs to  
+
+1. Install MOOSE which can be found here https://moose.ncbs.res.in/readthedocs/install/install.html  
+2. Install FindSim:  
+  - Clone this repository using  
+     `git clone https://github.com/BhallaLab/FindSim`
+
+  - or, clone specific branch such as "devel" using:
+     `git clone -b devel https://github.com/BhallaLab/FindSim`
+
 # File organization:
-	FindSim/             				: project directory  
-	FindSim/stable					: Stable branch. Stable version of `develop` branch  
-	FindSim/Curated					: Folder contains FindSim worksheets to which the model is well fit.
-	FindSim/models					: Model files 
-	FindSim/findSim.py				: Main findSim script  
-	FindSim/runAllParallel.py			: Batch/parallel wrapper script.  
-	FindSim/FindSim-Exptworksheet.xlsx		: Template worksheet with inline help and units, for Microsoft Excel.  
-	FindSim/FindSim-Exptworksheet.ods		: Template worksheet with inline help and units, for Libre Office.  
-	FindSim/FindSim-Schema.xml 			: Schema for tsv files for worksheet.  
-	FindSim/README.md				: This file  
+
+FindSim/             				: project directory  
+FindSim/stable					: Stable branch. Stable version of `develop` branch  
+FindSim/Curated					: Folder contains FindSim worksheets to which the model is well fit.
+FindSim/models					: Model files 
+FindSim/findSim.py				: Main findSim script  
+FindSim/runAllParallel.py			: Batch/parallel wrapper script.  
+FindSim/FindSim-Exptworksheet.xlsx		: Template worksheet with inline help and units, for Microsoft Excel.  
+FindSim/FindSim-Exptworksheet.ods		: Template worksheet with inline help and units, for Libre Office.  
+FindSim/FindSim-Schema.xml 			: Schema for tsv files for worksheet.  
+FindSim/README.md				: This file  
 						
-=============================================================================
 # Quick start: 
+
 A. Run one of the example experiments on the default model, generating a graph to compare model to experiment:  
-	To run the script, run the command in python and `synSynth7.g` is the latest model that is tested out the worksheets.  
-  	>python findSim.py Curated/FindSim-Jain2009-Fig2B.tsv --model models/synSynth7.g  
-  				or  
-  	>python findSim.py Curated/FindSim-Jain2009-Fig2B.tsv  
+To run the script, run the command in python and `synSynth7.g` is the latest model that is tested out the worksheets.  
+
+```
+python findSim.py Curated/FindSim-Jain2009-Fig2B.tsv --model models/synSynth7.g  
+```
+or,
+
+```
+python findSim.py Curated/FindSim-Jain2009-Fig2B.tsv  
+```
 
 B. Batch run:  
-	-runAllParallel.py script runs the findSim program on all tsv files in the specified directory, computes their scores, and prints out basic stats of the scores. It can do this in parallel using Python's multiprocessing library.  
+
+- runAllParallel.py script runs the findSim program on all tsv files in the specified directory, computes their scores, and prints out basic stats of the scores. It can do this in parallel using Python's multiprocessing library.  
 	
-	>python runAllParallel.py Curated -n 8  (run of the entire set of `Curated` experiments on 8 cores)  
-						or  
-	>python runAllParallel.py Directory (of tsv files) -n (Number of processes to spawn) --model (synSynth7.g)  
+```
+python runAllParallel.py Curated -n 8  (run of the entire set of `Curated` experiments on 8 cores)  
+```
+or,
 
-C. Syntax help:  
-	>python findSim.py -h  
-	>python runAllParallel.py -h  
+```
+python runAllParallel.py Directory (of tsv files) -n (Number of processes to spawn) --model (synSynth7.g)  
+```
 
+C. Help:  
 
-=============================================================================
+```
+python findSim.py -h  
+python runAllParallel.py -h  
+```
+
+# Extra
 
 Generating Figures for   
 "FindSim: a Framework for Integrating Neuronal Data and Signaling Models."  
-by  
-Nisha A. Viswan, G.V. HarshaRani, Melanie I. Stefan, Upinder S. Bhalla
+by  Nisha A. Viswan, G.V. HarshaRani, Melanie I. Stefan, Upinder S. Bhalla
 Front Neuroinform. 2018 Jun 26;12:38. doi: 10.3389/fninf.2018.00038. eCollection 2018.
 
 All these are run using the development branch "stable"  
@@ -88,8 +102,8 @@ python findSim.py Curated/FindSim-Ji2010_fig1C_ERK_acute.tsv --model models/synS
 Figure 7D:  
 python findSim.py Curated/FindSim-Bhalla1999_fig4C.tsv --model models/synSynth7.g  
 
-=============================================================================
 # Other resources
+
 Project is hosted at https://github.com/BhallaLab/FindSim
 
 The web template for experiment worksheet can be found here https://www.ncbs.res.in/faculty/bhalla-findsim/worksheet  
@@ -100,13 +114,16 @@ MOOSE documentation: http://moose.ncbs.res.in/readthedocs/install/index_install.
 
 Two papers were used as the initial basis for the models, and which in turn
 refer to a large number of experimental studies for their data:  
-	- Bhalla US., Iyengar R. Emergent properties of networks of biological signaling pathways. Science. 1999 Jan 15;283(5400):381-7.  
-	- Jain P, and Bhalla, U.S. Signaling logic of activity-triggered dendritic protein synthesis: an mTOR gate but not a feedback switch. PLoS Comput Biol. 2009 Feb;5(2):e1000287. Epub 2009 Feb 13  
+
+- Bhalla US., Iyengar R. Emergent properties of networks of biological signaling pathways. Science. 1999 Jan 15;283(5400):381-7.  
+- Jain P, and Bhalla, U.S. Signaling logic of activity-triggered dendritic protein synthesis: an mTOR gate but not a feedback switch. PLoS Comput Biol. 2009 Feb;5(2):e1000287. Epub 2009 Feb 13  
 
 Two further papers were used for some of the experiments:  
-	- Gu J, et al. Beta1,4-N-Acetylglucosaminyltransferase III down-regulates neurite outgrowth induced by costimulation of epidermal growth factor and integrins through the Ras/ERK signaling pathway in PC12 cells. Glycobiology. 2004 Feb;14(2):177-86. Epub 2003 Oct 23  
-	- Ji Y, et al. Acute and gradual increases in BDNF concentration elicit distinct signaling and functions in neurons. Nat Neurosci. 2010 Mar;13(3):302-9. doi: 10.1038/nn.2505. Epub 2010 Feb 21.  
 
-DOQCS database, from which models were derived: http://doqcs.ncbs.res.in  
-	Sivakumaran S. et al. The Database of Quantitative Cellular Signaling: management and analysis of chemical kinetic models of signaling networks.
-Bioinformatics. 2003. 19(3):408–415
+- Gu J, et al. Beta1,4-N-Acetylglucosaminyltransferase III down-regulates neurite outgrowth induced by costimulation of epidermal growth factor and integrins through the Ras/ERK signaling pathway in PC12 cells. Glycobiology. 2004 Feb;14(2):177-86. Epub 2003 Oct 23  
+- Ji Y, et al. Acute and gradual increases in BDNF concentration elicit distinct signaling and functions in neurons. Nat Neurosci. 2010 Mar;13(3):302-9. doi: 10.1038/nn.2505. Epub 2010 Feb 21.  
+
+DOQCS database, from which models were derived: http://doqcs.ncbs.res.in
+__Sivakumaran S. et al. The Database of Quantitative Cellular Signaling:
+management and analysis of chemical kinetic models of signaling networks.
+Bioinformatics. 2003. 19(3):408–415__

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Latest release is 1.1.0, which can be downloadable at
 # Quick start: 
 A. Run one of the example experiments on the default model, generating a graph to compare model to experiment:  
 	To run the script, run the command in python and `synSynth7.g` is the latest model that is tested out the worksheets.  
-  	>python findSim.py Curated/FindSim-Jain2009-Fig2B.tsv --model synSynth7.g  
+  	>python findSim.py Curated/FindSim-Jain2009-Fig2B.tsv --model models/synSynth7.g  
   				or  
   	>python findSim.py Curated/FindSim-Jain2009-Fig2B.tsv  
 

--- a/TestTSV/fepsp.tsv
+++ b/TestTSV/fepsp.tsv
@@ -54,13 +54,13 @@ field	fEPSP_peak
 useNormalization	False	
 Data		
 Time	Value	stderr
-6	0.2	0
-8	0.2	0
-15	0.6	0
-16	0.62	0
-17	0.7	0
-18	0.8	0
-20	0.9	0
+6	0.15	0
+8	0.15	0
+15	0.4	0
+16	0.45	0
+17	0.5	0
+18	0.55	0
+20	0.6	0
 		
 Model mapping		
 modelSource	internal	

--- a/TestTSV/fepsp.tsv
+++ b/TestTSV/fepsp.tsv
@@ -1,0 +1,80 @@
+Experiment metadata		
+transcriber	Upi	
+organization	NCBS	
+emailId	bhalla@ncbs.res.in	
+exptSource	None
+citationId	None
+authors	None
+journal	None. This is a purely fictional _experiment_ for the purposes of testing findSim
+		
+		
+Experiment context		
+exptType	TimeSeries	
+species	rat	
+cell-types	hippocampal CA1 pyramidal neuron	
+temperature (Celsius)	30	
+Include	all	
+details		
+notes	HFS, LTP	
+		
+Stimuli		
+compartment	dend	
+timeUnits	sec	
+quantityUnits	Hz	
+entities	synInput	
+field	rate	
+Data		
+Time	Value	
+0	0	
+10	100
+11	0	
+		
+Stimuli		
+compartment	dend	
+timeUnits	sec	
+quantityUnits	ratio	
+entities	synapse	
+field	weight	
+Data		
+Time	Value	
+0	1	
+10	1	
+11	0.4	
+		
+		
+Readouts		
+timeUnits	sec	
+quantityUnits	mV	
+useXlog	FALSE	
+useYlog	FALSE	
+ratioReferenceTime	1	
+ratioReferenceEntity	soma	
+entities	soma	
+field	fEPSP_peak	
+useNormalization	False	
+Data		
+Time	Value	stderr
+6	0.2	0
+8	0.2	0
+15	0.6	0
+16	0.62	0
+17	0.7	0
+18	0.8	0
+20	0.9	0
+		
+Model mapping		
+modelSource	internal	
+fileName	models/plastic8.py	
+citationId		
+citation		
+authors		
+modelSubset	all	
+modelLookup	soma:elec/soma,synInput:elec/head0/glu/sh/synapse/synInput,synapse:elec/head0/glu/sh/synapse	
+scoringFormula	abs((expt-sim)/(datarange+1e-9))	
+solver	none	
+notes		
+# Monitor response with a low stimulus amplitude/weight with initial 
+# test pulses 4 and 8 sec. Then give a 100Hz synaptic input at t = 10-11s.
+# Then monitor response at 15, 20 s.
+
+

--- a/__init__.py
+++ b/__init__.py
@@ -1,3 +1,3 @@
-import findSim
-import runAllParallel
+from FindSim import findSim
+from FindSim import runAllParallel
 __all__ = [ "findSim", "runAllParallel"]

--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,3 @@
+import findSim
+import runAllParallel
+__all__ = [ "findSim", "runAllParallel"]

--- a/__init__.py
+++ b/__init__.py
@@ -1,3 +1,0 @@
-from FindSim import findSim
-from FindSim import runAllParallel
-__all__ = [ "findSim", "runAllParallel"]

--- a/__main__.py
+++ b/__main__.py
@@ -10,8 +10,8 @@ __maintainer__       = "Dilawar Singh"
 __email__            = "dilawars@ncbs.res.in"
 __status__           = "Development"
 
-import findSim
-import runAllParallel
+from findsim import findSim
+from findsim import runAllParallel
 
 def run():
     findSim.main()

--- a/__main__.py
+++ b/__main__.py
@@ -10,8 +10,8 @@ __maintainer__       = "Dilawar Singh"
 __email__            = "dilawars@ncbs.res.in"
 __status__           = "Development"
 
-from findsim import findSim
-from findsim import runAllParallel
+from FindSim import findSim
+from FindSim import runAllParallel
 
 def run():
     findSim.main()

--- a/__main__.py
+++ b/__main__.py
@@ -1,0 +1,23 @@
+"""__main__.py: 
+
+Entry point for this package.
+"""
+    
+__author__           = "Dilawar Singh"
+__copyright__        = "Copyright 2017-, Dilawar Singh"
+__version__          = "1.0.0"
+__maintainer__       = "Dilawar Singh"
+__email__            = "dilawars@ncbs.res.in"
+__status__           = "Development"
+
+import findSim
+import runAllParallel
+
+def run():
+    findSim.main()
+
+def run_parallel():
+    runAllParallel.main()
+
+if __name__ == '__main__':
+    run()

--- a/__main__.py
+++ b/__main__.py
@@ -10,13 +10,13 @@ __maintainer__       = "Dilawar Singh"
 __email__            = "dilawars@ncbs.res.in"
 __status__           = "Development"
 
-from FindSim import findSim
-from FindSim import runAllParallel
 
 def run():
+    from FindSim import findSim
     findSim.main()
 
 def run_parallel():
+    from FindSim import runAllParallel
     runAllParallel.main()
 
 if __name__ == '__main__':

--- a/findSim.py
+++ b/findSim.py
@@ -717,7 +717,7 @@ def isNotDescendant( elm, ancestorSet ):
 def getObjParam( elm, field ):
     if field == 'Kd':
         if not elm.isA['ReacBase']:
-            raise SimError( "getObjParam: can only get Kd on a Reac, was: '{}'".format( obj.className ) )
+            raise SimError( "getObjParam: can only get Kd on a Reac, was: '{}'".format( elm.className ) )
         return elm.Kb/elm.Kf
     elif field == 'tau':
         # This is a little dubious, because order 1 reac has 1/conc.time
@@ -725,7 +725,7 @@ def getObjParam( elm, field ):
         # This latter is the Kf we want to use, assuming typical concs are
         # around 1 uM.
         if not elm.isA['ReacBase']:
-            raise SimError( "getObjParam: can only get tau on a Reac, was: '{}'".format( obj.className ) )
+            raise SimError( "getObjParam: can only get tau on a Reac, was: '{}'".format( elm.className ) )
         scaleKf = 0.001 ** (elm.numSubstrates-1)
         scaleKb = 0.001 ** (elm.numProducts-1)
         #print( "scaleKf={}; scaleKb={}, numsu ={}, numPrd={},Kb={},Kf={}".format( scaleKf, scaleKb, elm.numSubstrates, elm.numProducts, elm.Kb, elm.Kf ) )
@@ -1109,7 +1109,7 @@ def parseAndRunDoser( model, stims, readouts, modelId ):
             exactly one stimulus block, {} defined".format( len(stims)) )
     if len( readouts ) != 1:
         raise SimError( "parseAndRunDoser: Dose response run needs \
-            exactly one readout block, {} defined".format( len(readout) ) )
+            exactly one readout block, {} defined".format( len(readouts) ) )
     numLevels = len( readouts[0].data )
     
     if numLevels == 0:
@@ -1206,7 +1206,7 @@ def parseAndRunBarChart( model, stims, readouts, modelId ):
             one stimulus block, {} defined".format( len( stims ) ) )
     if len( readouts ) != 1:
         raise SimError( "parseAndRunBarChart: BarChart run needs exactly \
-            one readout block, {} defined".format( len( readout ) ) )
+            one readout block, {} defined".format( len( readouts ) ) )
     numLevels = len( readouts[0].data )
     
     if numLevels == 0:

--- a/findSim.py
+++ b/findSim.py
@@ -45,17 +45,20 @@ import ntpath
 import time
 import imp      # This is apparently deprecated in Python 3.4 and up
 import matplotlib.pyplot as pyplot
-import mpld3
 
-#mpld3 hack
+# mpld3 hack
 # suggested: https://github.com/mpld3/mpld3/issues/434
 import json
+
 class NumpyEncoder(json.JSONEncoder):
+    # pylint: disable=method-hidden
     def default(self, obj):
         import numpy as np
         if isinstance(obj, np.ndarray):
             return obj.tolist()
         return json.JSONEncoder.default(self, obj)
+
+import mpld3
 from mpld3 import _display
 _display.NumpyEncoder = NumpyEncoder
 

--- a/findSim.py
+++ b/findSim.py
@@ -31,9 +31,9 @@
 ** also known as GENESIS 3 base code.
 **           copyright (C) 2003-2018 Upinder S. Bhalla. and NCBS
 **********************************************************************/
-
 '''
-from __future__ import print_function
+
+from __future__ import print_function, division
 import heapq
 import pylab
 import numpy as np
@@ -1737,6 +1737,7 @@ def innerMain( script, modelFile = "model/synSynth7.g", dumpFname = "", paramFna
         if moose.exists( '/library' ):
             moose.delete( '/library' )
         return -1.0
+
 # Run the 'main' if this script is executed standalone.
 if __name__ == '__main__':
     main()

--- a/findSim.py
+++ b/findSim.py
@@ -33,9 +33,8 @@
 **********************************************************************/
 
 '''
-from __future__ import print_function
+from __future__ import print_function, absolute_import
 import heapq
-#import pylab
 import numpy as np
 import sys
 import argparse
@@ -45,8 +44,8 @@ import re
 import ntpath
 import time
 import imp      # This is apparently deprecated in Python 3.4 and up
-
-import matplotlib.pyplot as pyplot,mpld3
+import matplotlib.pyplot as pyplot
+import mpld3
 
 #mpld3 hack
 # suggested: https://github.com/mpld3/mpld3/issues/434
@@ -59,7 +58,6 @@ class NumpyEncoder(json.JSONEncoder):
         return json.JSONEncoder.default(self, obj)
 from mpld3 import _display
 _display.NumpyEncoder = NumpyEncoder
-
 
 convertTimeUnits = {('sec','s') : 1.0, 
     ('ms','millisec', 'msec') : 1e-3,('us','microsec') : 1e-6, 

--- a/models/loadhh.py
+++ b/models/loadhh.py
@@ -8,5 +8,7 @@ def load():
             ['Na', 'soma', 'Gbar', '1200' ],
             ['K', 'soma', 'Gbar', '360' ]],
     )
+    return rdes
+
+def build( rdes ):
     rdes.buildModel()
-    return rdes.model

--- a/models/loadhh.py
+++ b/models/loadhh.py
@@ -2,7 +2,7 @@ import moose
 import rdesigneur as rd
 def load():
     rdes = rd.rdesigneur(
-        turnOffElec = True,
+        turnOffElec = False,
         chanProto = [['make_HH_Na()', 'Na'], ['make_HH_K()', 'K']],
         chanDistrib = [
             ['Na', 'soma', 'Gbar', '1200' ],

--- a/models/plastic8.py
+++ b/models/plastic8.py
@@ -19,7 +19,7 @@ def load():
         chemDt = 0.002,
         diffDt = 0.002,
         chemPlotDt = 0.02,
-        turnOffElec = True, #FindSim needs to create Vclamp and then solver.
+        turnOffElec = False,#FindSim needs to create Vclamp and then solver.
         useGssa = False,
         # cellProto syntax: ['ballAndStick', 'name', somaDia, somaLength, dendDia, dendLength, numDendSegments ]
         cellProto = [['ballAndStick', 'soma', 12e-6, 12e-6, 4e-6, 100e-6, 1 ]],
@@ -52,6 +52,11 @@ def load():
         stimList = [['head#', '0.2','glu', 'periodicsyn', '0']],
     )
     moose.seed(1234567)
+    
+    return rdes
+
+
+def build( rdes ):
     rdes.buildModel()
     #moose.element( '/model/chem/dend/ksolve' ).numThreads = 4
     #moose.showfield( '/model/chem/dend/ksolve' )
@@ -63,5 +68,3 @@ def load():
     #moose.showmsg( '/model/elec/head0/glu/sh/synapse/synInput_rs' )
     #import presettle_CaMKII_MAPK7_init
     moose.reinit()
-    
-    return rdes.model

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 numpy
 matplotlib
 networkx
+pymoose
+mpld3
+scipy

--- a/runAllParallel.py
+++ b/runAllParallel.py
@@ -36,7 +36,7 @@ directory, computes their scores, and prints out basic stats of the scores.
 It can do this in parallel using Python's multiprocessing library.
 '''
 
-from __future__ import print_function
+from __future__ import print_function, division
 import numpy
 import argparse
 import os
@@ -115,8 +115,8 @@ def main():
             numGood += 1
             sumScore += j * w
             sumWts += w
-    print( "Weighted Score out of {:.0f} good runs = {:.3f}. Runtime = {:.3f} sec".format( numGood, sumScore / sumWts, time.time() - t0 ) )
-        #print( "{0} : {1:.2f}".format( i, j ) )
+    print( "Weighted Score out of {:.0f} good runs = {:.3f}. Runtime = {:.3f} sec".format(
+        numGood, sumScore / sumWts, time.time() - t0 ) )
 
         
 # Run the 'main' if this script is executed standalone.

--- a/runAllParallel.py
+++ b/runAllParallel.py
@@ -35,8 +35,8 @@ This script runs the findSim program on all tsv files in the specified
 directory, computes their scores, and prints out basic stats of the scores.
 It can do this in parallel using Python's multiprocessing library.
 '''
+from __future__ import print_function, division
 
-from __future__ import print_function, division, absolute_import
 import numpy
 import argparse
 import os
@@ -45,13 +45,16 @@ import argparse
 import time
 from multiprocessing import Pool
 
-# Python's pain (import and scripts). See  https://stackoverflow.com/a/49480246/1805129
+# Python 2/3 pain (import and scripts). See  https://stackoverflow.com/a/49480246/1805129
 # This 'hack' is here to make sure that `python runAllParallel.py` also works
 # and described in old documents. 
-if __package__ is None or __package__ == '':
-    import findSim
+if sys.version_info.major > 2:
+    if __package__ is None or __package__ == '':
+        import findSim
+    else:
+        from FindSim import findSim
 else:
-    from FindSim import findSim
+    import findSim
 
 resultCount = 0
 def reportReturn( result ):

--- a/runAllParallel.py
+++ b/runAllParallel.py
@@ -36,7 +36,7 @@ directory, computes their scores, and prints out basic stats of the scores.
 It can do this in parallel using Python's multiprocessing library.
 '''
 
-from __future__ import print_function, division
+from __future__ import print_function, division, absolute_import
 import numpy
 import argparse
 import os

--- a/runAllParallel.py
+++ b/runAllParallel.py
@@ -1,5 +1,5 @@
+# -*- coding: utf-8 -*-
 
-# 
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
 # published by the Free Software Foundation; either version 3, or
@@ -43,7 +43,7 @@ import os
 import sys
 import argparse
 import time
-import findSim
+from . import findSim
 from multiprocessing import Pool
 
 resultCount = 0

--- a/runAllParallel.py
+++ b/runAllParallel.py
@@ -43,8 +43,15 @@ import os
 import sys
 import argparse
 import time
-from . import findSim
 from multiprocessing import Pool
+
+# Python's pain (import and scripts). See  https://stackoverflow.com/a/49480246/1805129
+# This 'hack' is here to make sure that `python runAllParallel.py` also works
+# and described in old documents. 
+if __package__ is None or __package__ == '':
+    import findSim
+else:
+    from FindSim import findSim
 
 resultCount = 0
 def reportReturn( result ):

--- a/setup.py
+++ b/setup.py
@@ -1,23 +1,40 @@
+"""setup.py: 
+    Packaging script for FindSim.
+"""
+    
+__author__           = "Dilawar Singh"
+__copyright__        = "Copyright 2017-, Dilawar Singh"
+__version__          = "1.0.0"
+__maintainer__       = "Dilawar Singh"
+__email__            = "dilawars@ncbs.res.in"
+__status__           = "Development"
+
 import os
 import sys
-from setuptools import setup
+import setuptools
 
 with open("README.md") as f:
     readme = f.read()
 
-setup(
-    name = "findsim",
-    version = "1.0.0",
-    description = "A Framework for Integrating Neuronal Data and Singalling Model",
-    long_description = readme,
-    long_description_content_type = "text/markdown",
-    packages = [ "findsim" ],
-    package_dir = { "findsim" : "."},
-    install_requires = [ 'pymoose', 'scipy' ],
-    author = "Dilawar Singh",   # author of packaging. See contributors for
-                                # autor of findsime
-    author_email = "dilawar@ncbs.res.in",
-    url = "http://github.com/BhallaLab/FindSime",
-    package_data = { "findsim" : [ '*.csv' ] },
-    license='GPLv3'
-)
+setuptools.setup(
+        name = "findsim",
+        version = "1.0.0",
+        description = "A Framework for Integrating Neuronal Data and Singalling Model",
+        long_description = readme,
+        long_description_content_type = "text/markdown",
+        packages = [ "findsim" ],
+        package_dir = { "findsim" : "."},
+        install_requires = [ 'pymoose', 'scipy' ],
+        author = "Dilawar Singh",   # author of packaging. See contributors for
+        # autor of findsime
+        author_email = "dilawar@ncbs.res.in",
+        url = "http://github.com/BhallaLab/FindSime",
+        package_data = { "findsim" : [ '*.csv' ] },
+        license='GPLv3',
+        entry_points = {
+            'console_scripts' : [
+                'findsim = findsim.__main__:run',
+                'findsim_parallel = findsim.__main__:run_parallel'
+                ]
+            },
+        )

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setuptools.setup(
         long_description_content_type = "text/markdown",
         packages = [ "FindSim" ],
         package_dir = { "FindSim" : "."},
-        install_requires = [ 'pymoose', 'scipy' ],
+        install_requires = [ 'pymoose', 'scipy', 'mpld3', 'networkx' ],
         author = "Dilawar Singh",   # author of packaging. See contributors for
                                     # the list of authors 
         author_email = "dilawar@ncbs.res.in",

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,23 @@
+import os
+import sys
+from setuptools import setup
+
+with open("README.md") as f:
+    readme = f.read()
+
+setup(
+    name = "findsim",
+    version = "1.0.0",
+    description = "A Framework for Integrating Neuronal Data and Singalling Model",
+    long_description = readme,
+    long_description_content_type = "text/markdown",
+    packages = [ "findsim" ],
+    package_dir = { "findsim" : "."},
+    install_requires = [ 'pymoose', 'scipy' ],
+    author = "Dilawar Singh",   # author of packaging. See contributors for
+                                # autor of findsime
+    author_email = "dilawar@ncbs.res.in",
+    url = "http://github.com/BhallaLab/FindSime",
+    package_data = { "findsim" : [ '*.csv' ] },
+    license='GPLv3'
+)

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ import setuptools
 with open("README.md") as f:
     readme = f.read()
 
-version_ = '1.0.0'
+version_ = '1.0.1'
 isPre_   = True
 if isPre_:
     import datetime

--- a/setup.py
+++ b/setup.py
@@ -17,19 +17,20 @@ with open("README.md") as f:
     readme = f.read()
 
 setuptools.setup(
-        name = "findsim",
+        name = "FindSim",
         version = "1.0.0",
         description = "A Framework for Integrating Neuronal Data and Singalling Model",
         long_description = readme,
         long_description_content_type = "text/markdown",
-        packages = [ "findsim" ],
-        package_dir = { "findsim" : "."},
+        packages = [ "FindSim" ],
+        package_dir = { "FindSim" : "."},
         install_requires = [ 'pymoose', 'scipy' ],
         author = "Dilawar Singh",   # author of packaging. See contributors for
-        # autor of findsime
+                                    # the list of authors 
         author_email = "dilawar@ncbs.res.in",
         url = "http://github.com/BhallaLab/FindSime",
-        package_data = { "findsim" : [ '*.csv' ] },
+        package_data = { "FindSim" : [ '*.csv', '*.xml' ] },
+        include_pacakge_data  = True,
         license='GPLv3',
         entry_points = {
             'console_scripts' : [

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ import setuptools
 with open("README.md") as f:
     readme = f.read()
 
-version_ = '1.0.1'
+version_ = '1.0.2'
 isPre_   = True
 if isPre_:
     import datetime

--- a/setup.py
+++ b/setup.py
@@ -4,10 +4,8 @@
     
 __author__           = "Dilawar Singh"
 __copyright__        = "Copyright 2017-, Dilawar Singh"
-__version__          = "1.0.0"
 __maintainer__       = "Dilawar Singh"
 __email__            = "dilawars@ncbs.res.in"
-__status__           = "Development"
 
 import os
 import sys
@@ -18,7 +16,7 @@ with open("README.md") as f:
 
 setuptools.setup(
         name = "FindSim",
-        version = "1.0.0",
+        version = "0.0.1",
         description = "A Framework for Integrating Neuronal Data and Singalling Model",
         long_description = readme,
         long_description_content_type = "text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -34,8 +34,8 @@ setuptools.setup(
         license='GPLv3',
         entry_points = {
             'console_scripts' : [
-                'findsim = findsim.__main__:run',
-                'findsim_parallel = findsim.__main__:run_parallel'
+                'findsim = FindSim.__main__:run',
+                'findsim_parallel = FindSim.__main__:run_parallel'
                 ]
             },
         )

--- a/setup.py
+++ b/setup.py
@@ -14,9 +14,18 @@ import setuptools
 with open("README.md") as f:
     readme = f.read()
 
+version_ = '1.0.0'
+isPre_   = True
+if isPre_:
+    import datetime
+    version_ += '.dev' + datetime.datetime.today().strftime('%Y%m%d')
+    print( "[INFO ] Building version %s" % version_ )
+    
+
+
 setuptools.setup(
         name = "FindSim",
-        version = "0.0.1",
+        version = version_,
         description = "A Framework for Integrating Neuronal Data and Singalling Model",
         long_description = readme,
         long_description_content_type = "text/markdown",
@@ -28,7 +37,6 @@ setuptools.setup(
         author_email = "dilawar@ncbs.res.in",
         url = "http://github.com/BhallaLab/FindSime",
         package_data = { "FindSim" : [ '*.csv', '*.xml' ] },
-        include_pacakge_data  = True,
         license='GPLv3',
         entry_points = {
             'console_scripts' : [

--- a/test.sh
+++ b/test.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
-
 set -e 
-set -x
 
 # virtualenv does not require --user
 PYTHON=$(which python)
@@ -35,10 +33,10 @@ for _tsv in $(find ./TestTSV -name *.tsv -type f); do
     $PYTHON findSim.py ${_tsv} --model models/synSynth7.g
 done
 
-findsim ./Curated/FindSim-Jain2009_Fig4F.tsv --model models/synSynth7.g
-findsim ./Curated/FindSim-Bhalla1999_fig2B.tsv --model models/synSynth7.g
+time findsim ./Curated/FindSim-Jain2009_Fig4F.tsv --model models/synSynth7.g
+time findsim ./Curated/FindSim-Bhalla1999_fig2B.tsv --model models/synSynth7.g
 # Following takes a lot of time to run.
 #findsim ./Curated/FindSim-Gu2004_fig3B.tsv --model models/synSynth7.g
-findsim ./Curated/FindSim-Ji2010_fig1C_ERK_acute.tsv --model models/synSynth7.g
-findsim ./Curated/FindSim-Bhalla1999_fig4C.tsv --model models/synSynth7.g
+time findsim ./Curated/FindSim-Ji2010_fig1C_ERK_acute.tsv --model models/synSynth7.g
+time findsim ./Curated/FindSim-Bhalla1999_fig4C.tsv --model models/synSynth7.g
 timeout 60 findsim_parallel Curated -n 4 || echo "Timedout. We call it success!"

--- a/test.sh
+++ b/test.sh
@@ -17,7 +17,7 @@ else
     $PYTHON -m pip install --upgrade 
 fi
 
-$PYTHON setup.py install --user
+# travis.yml should install FindSim
 # $PYTHON -m pip install Jinja2
 # $PYTHON -m pip install mpld3
 # $PYTHON -m pip install pymoose --pre --upgrade
@@ -40,4 +40,4 @@ findsim ./Curated/FindSim-Bhalla1999_fig2B.tsv --model models/synSynth7.g
 #findsim ./Curated/FindSim-Gu2004_fig3B.tsv --model models/synSynth7.g
 findsim ./Curated/FindSim-Ji2010_fig1C_ERK_acute.tsv --model models/synSynth7.g
 findsim ./Curated/FindSim-Bhalla1999_fig4C.tsv --model models/synSynth7.g
-findsim_parallel Curated -N 8
+findsim_parallel Curated -n 4

--- a/test.sh
+++ b/test.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -e 
+set -x
 
 # virtualenv does not require --user
 PYTHON=$(which python)
@@ -14,7 +15,7 @@ if [ "$PYTHON_VERSION" -eq "27" ]; then
 else
     # $PYTHON -m pip uninstall matplotlib -y || echo "Failed to remove matplotlib"
     $PYTHON -m pip install matplotlib --upgrade 
-    $PYTHON -m pip install --upgrade 
+    $PYTHON -m pip install scipy --upgrade 
 fi
 
 # travis.yml should install FindSim

--- a/test.sh
+++ b/test.sh
@@ -16,10 +16,12 @@ else
     $PYTHON -m pip install matplotlib --upgrade 
     $PYTHON -m pip install --upgrade 
 fi
-$PYTHON -m pip install Jinja2
-$PYTHON -m pip install mpld3
-$PYTHON -m pip install pymoose --pre --upgrade
-$PYTHON -m pip install pylint numpy --upgrade 
+
+$PYTHON setup.py install --user
+# $PYTHON -m pip install Jinja2
+# $PYTHON -m pip install mpld3
+# $PYTHON -m pip install pymoose --pre --upgrade
+# $PYTHON -m pip install pylint numpy --upgrade
 
 find . -type f -name "*.py" | xargs -I file $PYTHON -m pylint \
     --disable=no-member \
@@ -32,9 +34,10 @@ for _tsv in $(find ./TestTSV -name *.tsv -type f); do
     $PYTHON findSim.py ${_tsv} --model models/synSynth7.g
 done
 
-$PYTHON findSim.py ./Curated/FindSim-Jain2009_Fig4F.tsv --model models/synSynth7.g
-$PYTHON findSim.py ./Curated/FindSim-Bhalla1999_fig2B.tsv --model models/synSynth7.g
+findsim ./Curated/FindSim-Jain2009_Fig4F.tsv --model models/synSynth7.g
+findsim ./Curated/FindSim-Bhalla1999_fig2B.tsv --model models/synSynth7.g
 # Following takes a lot of time to run.
-#$PYTHON findSim.py ./Curated/FindSim-Gu2004_fig3B.tsv --model models/synSynth7.g
-$PYTHON findSim.py ./Curated/FindSim-Ji2010_fig1C_ERK_acute.tsv --model models/synSynth7.g
-$PYTHON findSim.py ./Curated/FindSim-Bhalla1999_fig4C.tsv --model models/synSynth7.g
+#findsim ./Curated/FindSim-Gu2004_fig3B.tsv --model models/synSynth7.g
+findsim ./Curated/FindSim-Ji2010_fig1C_ERK_acute.tsv --model models/synSynth7.g
+findsim ./Curated/FindSim-Bhalla1999_fig4C.tsv --model models/synSynth7.g
+findsim_parallel Curated -N 8

--- a/test.sh
+++ b/test.sh
@@ -40,4 +40,4 @@ findsim ./Curated/FindSim-Bhalla1999_fig2B.tsv --model models/synSynth7.g
 #findsim ./Curated/FindSim-Gu2004_fig3B.tsv --model models/synSynth7.g
 findsim ./Curated/FindSim-Ji2010_fig1C_ERK_acute.tsv --model models/synSynth7.g
 findsim ./Curated/FindSim-Bhalla1999_fig4C.tsv --model models/synSynth7.g
-findsim_parallel Curated -n 4
+timeout 60 findsim_parallel Curated -n 4 || echo "Timedout. We call it success!"

--- a/test.sh
+++ b/test.sh
@@ -18,10 +18,10 @@ else
 fi
 
 # travis.yml should install FindSim
-# $PYTHON -m pip install Jinja2
+$PYTHON -m pip install Jinja2 --upgrade
+$PYTHON -m pip install pylint --upgrade
 # $PYTHON -m pip install mpld3
 # $PYTHON -m pip install pymoose --pre --upgrade
-# $PYTHON -m pip install pylint numpy --upgrade
 
 find . -type f -name "*.py" | xargs -I file $PYTHON -m pylint \
     --disable=no-member \


### PR DESCRIPTION
Closes #18. The package is on nightly channel, to install it using pip, one should use `--pre` with pip.

    $ pip install FindSim --user --pre

Works with both python2 and python3.

# Install 

To install last stable release (__NOTE__ This uses moose version 3.1.4 (outdated
with this release))

     $ pip install FindSim   #  not uploaded yet.

Or, to install the nightly built,

     $ pip install FinSim --pre   # recommended and available

Alternatively, you can download the source code and install it yourself.

1. Install MOOSE which can be found here https://moose.ncbs.res.in/readthedocs/install/install.html  
2. Install FindSim

```
git clone https://github.com/BhallaLab/FindSim
cd FindSim
python setup.py install  
```

After successful installation, two new commands are available at your disposal
`findsim` and `findsim_parallel`. To see the help message, pass `-h` option to
either of these commands. For example, `findsim -h` will show you following
message.

```
usage: findsim [-h] [-m MODEL] [-d DUMP_SUBSET] [-p PARAM_FILE] [-t] [-hp]
               [-hs] [-o] [-s SCALE_PARAM SCALE_PARAM SCALE_PARAM]
               [-settle_time SETTLE_TIME]
               script

FindSim argument parser This program loads a kinetic model, and runs it with
the specified stimuli. The output is then compared with expected output
specified in the same file, to generate a model score.

positional arguments:
  script                Required: filename of experiment spec, in tsv format.

optional arguments:
  -h, --help            show this help message and exit
  -m MODEL, --model MODEL
                        Optional: model filename, .g or .xml
  -d DUMP_SUBSET, --dump_subset DUMP_SUBSET
                        Optional: dump selected subset of model into named
                        file
  -p PARAM_FILE, --param_file PARAM_FILE
                        Optional: Generate file of tweakable params belonging
                        to selected subset of model
  -t, --tabulate_output
                        Flag: Print table of plot values. Default is NOT to
                        print table
  -hp, --hide_plot      Hide plot output of simulation along with expected
                        values. Default is to show plot.
  -hs, --hide_subplots  Hide subplot output of simulation. By default the
                        graphs include dotted lines to indicate individual
                        quantities (e.g., states of a molecule) that are being
                        summed to give a total response. This flag turns off
                        just those dotted lines, while leaving the main plot
                        intact.
  -o, --optimize_elec   Optimize electrical computation. By default the
                        electrical computation runs for the entire duration of
                        the simulation. With this flag the system turns off
                        the electrical engine except during the times when
                        electrical stimuli are being given. This can be *much*
                        faster.
  -s SCALE_PARAM SCALE_PARAM SCALE_PARAM, --scale_param SCALE_PARAM SCALE_PARAM SCALE_PARAM
                        Scale specified object.field by ratio.
  -settle_time SETTLE_TIME, --settle_time SETTLE_TIME
                        Run model for specified settle time and return dict of
                        {path,conc}.
						
```

Command `findsim_parellel` is a helper utility: it runs multiple simulations
using `findsim` in parellel.


